### PR TITLE
CI builder was issuing warning due to darwin and other enviroments. 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -50,21 +50,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1650161686,
@@ -97,7 +82,6 @@
       "inputs": {
         "agda": "agda",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,88 +1,58 @@
 {
   "nodes": {
-    "agda": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1653327095,
-        "narHash": "sha256-wJIRUOSDnccBQIz1s3s7gp7E+FjIMylBBtQZiGIZkgo=",
-        "owner": "agda",
-        "repo": "agda",
-        "rev": "215a31a1ed6ff687f212173cbd8a04395b66035c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "agda",
-        "repo": "agda",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
+    "agda-categories": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "lastModified": 1653613155,
+        "narHash": "sha256-xYDiewH8F2wZ//4yg3nXZs6yu8rGIaRpQuzXfba70gs=",
+        "owner": "agda",
+        "repo": "agda-categories",
+        "rev": "45798f85cde25c12dfff069a245ca9042c04b9b0",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
+        "owner": "agda",
+        "repo": "agda-categories",
         "type": "github"
       }
     },
-    "flake-utils": {
+    "agda-stdlib": {
+      "flake": false,
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "lastModified": 1654025879,
+        "narHash": "sha256-DEKjQlHMkNUDFXsWY7dIUFj3V/LmAyi8rzzUV395q5E=",
+        "owner": "agda",
+        "repo": "agda-stdlib",
+        "rev": "95270b78d8d6ded67fcdf94095a056a0245de547",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "agda",
+        "repo": "agda-stdlib",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650161686,
-        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
+        "lastModified": 1655273078,
+        "narHash": "sha256-jlcD35mFKn7CQHUgUa0E79QrS5+5A+/Gh3BI2y/PC3U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
+        "rev": "29399e5ad1660668b61247c99894fc2fb97b4e74",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1650726686,
-        "narHash": "sha256-hE5PCqQlsdgWH3AUTwesvjZWs5ZUZ8SjMS5cnFB6W54=",
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "rev": "3c0f57e36ed0cf9947281e3b31f1bebb7ce5d4a1",
         "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
       }
     },
     "root": {
       "inputs": {
-        "agda": "agda",
-        "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs_2"
+        "agda-categories": "agda-categories",
+        "agda-stdlib": "agda-stdlib",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,29 +1,32 @@
 {
   description = "Denotational Zero Knowledge Proofs";
-
-  inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
-    flake-compat = {
+  inputs = 
+  {
+    flake-compat = 
+    {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
     agda.url = "github:agda/agda";
   };
 
-  outputs = { self, nixpkgs, flake-utils, agda, ... }:
-  flake-utils.lib.eachDefaultSystem
-  (system:
+  outputs = { self, nixpkgs, agda, ... }:
   let
-    pkgs = import nixpkgs { inherit system; };
+    pkgs = nixpkgs.legacyPackages.x86_64-linux;
   in
   {
-    devShell = pkgs.mkShell {
-      buildInputs = [
+    # restrict which systems to build in CI
+    herculesCI.ciSystems = ["x86_64-linux"];
+    devShells.x86_64-linux.default = pkgs.mkShell 
+    {
+      buildInputs = 
+      [
         pkgs.nixpkgs-fmt
         (pkgs.agda.withPackages (ps: [
           (ps.standard-library.overrideAttrs (oldAttrs: {
             version = "2.0";
-            src =  pkgs.fetchFromGitHub {
+            src =  pkgs.fetchFromGitHub 
+            {
               repo = "agda-stdlib";
               owner = "agda";
               rev = "6e79234dcd47b7ca1d232b16c9270c33ff42fb84";
@@ -34,7 +37,5 @@
         ]))
       ];
     };
-  }
-  );
-
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,41 +1,29 @@
 {
   description = "Denotational Zero Knowledge Proofs";
-  inputs = 
-  {
-    flake-compat = 
-    {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
-    agda.url = "github:agda/agda";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    agda-stdlib = { url = "github:agda/agda-stdlib"; flake = false; };
+    agda-categories = { url = "github:agda/agda-categories"; flake = false; };
   };
 
-  outputs = { self, nixpkgs, agda, ... }:
-  let
-    pkgs = nixpkgs.legacyPackages.x86_64-linux;
-  in
-  {
-    # restrict which systems to build in CI
-    herculesCI.ciSystems = ["x86_64-linux"];
-    devShells.x86_64-linux.default = pkgs.mkShell 
+  outputs = { self, nixpkgs, ... }@inputs:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: nixpkgs.legacyPackages.${system});
+    in
     {
-      buildInputs = 
-      [
-        pkgs.nixpkgs-fmt
-        (pkgs.agda.withPackages (ps: [
-          (ps.standard-library.overrideAttrs (oldAttrs: {
-            version = "2.0";
-            src =  pkgs.fetchFromGitHub 
-            {
-              repo = "agda-stdlib";
-              owner = "agda";
-              rev = "6e79234dcd47b7ca1d232b16c9270c33ff42fb84";
-              sha256 = "0n1xksqz0d2vxd4l45mxkab2j9hz9g291zgkjl76h5cn0p9wylk3";
-            };
-          }))
-          ps.agda-categories
-        ]))
-      ];
+      devShells = forAllSystems (system: rec {
+        default = nixpkgsFor.${system}.mkShell {
+          packages = [
+            (nixpkgsFor.${system}.agda.withPackages (ps: [
+              (ps.standard-library.overrideAttrs (oldAttrs: { version = "2.0-dev"; src = inputs.agda-stdlib; }))
+              ps.agda-categories
+            ]))
+          ];
+        };
+      });
+      herculesCI.ciSystems = [ "x86_64-linux" "aarch64-linux" ];
     };
-  };
 }


### PR DESCRIPTION
This repo currently provides a single devshell, for unknown reasons flake-utils was being applied with *all* default systems.
As a result the CI/builder was issuing warnings.

To avoid this, and maintain clearly readable code, I have removed flake-utils and provided an instruction for herculeseCI which will prevent any future warnings.